### PR TITLE
Fixed null reference exception

### DIFF
--- a/Part 3 - MediaSessionCompat/Services/MediaPlayerService.cs
+++ b/Part 3 - MediaSessionCompat/Services/MediaPlayerService.cs
@@ -39,12 +39,15 @@ namespace BackgroundStreamingAudio.Services
         private MediaSessionCompat mediaSessionCompat;
         public MediaControllerCompat mediaControllerCompat;
 
-        public int MediaPlayerState
-        {
-            get{
-                return mediaControllerCompat.PlaybackState.State;
-            }
-        }
+		public int MediaPlayerState
+		{
+			get{
+				return (mediaControllerCompat.PlaybackState != null ? 
+					mediaControllerCompat.PlaybackState.State: 
+					PlaybackStateCompat.StateNone);
+			}
+		}
+
 
         private WifiManager wifiManager;
         private WifiManager.WifiLock wifiLock;


### PR DESCRIPTION
The "mediaControllerCompat.PlaybackState" is null on initial playback
and throws a null reference exception. I added a null check and return
"PlaybackStateCompat.StateNone" if the playback state is null.
