### PR TITLE
Update dead links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # AndroidStreamingAudio
 Series of Samples of streaming audio in background service in Xamarin.Android
 
-1. Streaming Music : [Blog](http://blog.xamarin.com/background-audio-streaming-with-xamarin.android/)
-2. Lock Screen Music Controls : [Blog](http://blog.xamarin.com/lock-screen-music-controls-in-xamarin.android/)
+1. Streaming Music : [Blog](https://devblogs.microsoft.com/xamarin/background-audio-streaming-with-xamarin-android/)
+2. Lock Screen Music Controls : [Blog](https://devblogs.microsoft.com/xamarin/lock-screen-music-controls-in-xamarin-android/)
 3. MediaSessionCompat: Thanks to [martijn00](http://github.com/martijn00)
 
 


### PR DESCRIPTION
The links on the README are now dead, presumably referring the old location of the blog.
This PR only updates these links.